### PR TITLE
Fix: infinite mob effects being dropped immediately

### DIFF
--- a/common/src/main/java/ac/boar/anticheat/ack/BoarDefaultAcknowledgments.java
+++ b/common/src/main/java/ac/boar/anticheat/ack/BoarDefaultAcknowledgments.java
@@ -357,7 +357,9 @@ public final class BoarDefaultAcknowledgments {
 
     private static void handleMobEffect(BoarPlayer player, MobEffectAck ack) {
         if (ack.event() == MobEffectPacket.Event.ADD || ack.event() == MobEffectPacket.Event.MODIFY) {
-            player.getActiveEffects().put(ack.effect(), new StatusEffect(ack.effect(), ack.amplifier(), ack.duration() + 1));
+            final int raw = ack.duration();
+            final int duration = raw < 0 || raw == Integer.MAX_VALUE ? Integer.MAX_VALUE : raw + 1;
+            player.getActiveEffects().put(ack.effect(), new StatusEffect(ack.effect(), ack.amplifier(), duration));
         } else if (ack.event() == MobEffectPacket.Event.REMOVE) {
             player.getActiveEffects().remove(ack.effect());
         }


### PR DESCRIPTION
Java sends -1 for infinite mob effects and Geyser passes it through. `handleMobEffect` stores it as `duration + 1`, which lands on 0, and `BoarPlayer#tick` drops any effect at 0. So infinite effects die the tick after they're applied.

With jump boost gone, Boar predicts a 0.42 jump while the client jumps 0.42 + 0.1 * (amplifier + 1), rewinding the player on every jump. Levitation too.

Tested on my live server with `/effect give <player> jump_boost infinite 1`, rubber-banding is gone.