### PR TITLE
Fix: Clear certainVelocity on teleport accept

### DIFF
--- a/common/src/main/java/ac/boar/anticheat/packets/input/teleport/TeleportHandler.java
+++ b/common/src/main/java/ac/boar/anticheat/packets/input/teleport/TeleportHandler.java
@@ -61,6 +61,7 @@ public class TeleportHandler {
         player.setPos(data.getPosition().down(player.getYOffset()));
         player.unvalidatedPosition = player.prevUnvalidatedPosition = player.position.clone();
         player.velocity = Vec3.ZERO.clone();
+        player.certainVelocity = null;
         player.predictionResult = new PredictionData(Vec3.ZERO, Vec3.ZERO, Vec3.ZERO); // Yep!
         player.onGround = false;
 


### PR DESCRIPTION
If a velocity packet is acked while the anticheat is waiting for a teleport, the velocity is stored in `certainVelocity`. When the teleport is accepted, the simulation's velocity is zeroed, but is then immediately overriden by `certainVelocity`, causing a desync.

This can be reproduced by being teleported after the player's velocity is set, e.g. throwing a pearl and taking knockback right before the pearl lands. The window of time where this can happen is the same as the player's latency, so this becomes a bigger issue on high-latency connections.

Below is a clip of this desync being reproduced using a server-side plugin:

https://github.com/user-attachments/assets/9f0a3cec-e591-48c1-bbde-6f65c06150c7

This PR fixes the issue by clearing `certainVelocity` on teleport.
