### PR TITLE
Fix: NPE on session leave before init

### DIFF
--- a/geyser/src/main/java/ac/boar/geyser/GeyserBoar.java
+++ b/geyser/src/main/java/ac/boar/geyser/GeyserBoar.java
@@ -7,6 +7,7 @@ import ac.boar.anticheat.check.api.BoarDefaultChecks;
 import ac.boar.anticheat.config.Config;
 import ac.boar.anticheat.config.ConfigLoader;
 import ac.boar.anticheat.player.BoarPlayer;
+import ac.boar.anticheat.player.BoarPlayerManager;
 import ac.boar.protocol.BoarDefaultPacketListeners;
 import ac.boar.geyser.model.GeyserMessageRecipient;
 import ac.boar.geyser.player.GeyserPlayerManager;
@@ -55,16 +56,25 @@ public class GeyserBoar implements Extension {
 
     @Subscribe
     public void onSessionLeave(SessionDisconnectEvent event) {
-        BoarPlayer player = Boar.getInstance().getPlayerManager().remove(event.connection());
-        if (player == null) {
+        // A session can disconnect before the initialization event has run (while the extension is
+        // still loading, or after an init that did not complete), when the player manager does not
+        // exist yet. The platform owns the manager, so prefer it over the static accessor.
+        BoarPlayerManager<?> playerManager = this.platform != null
+                ? this.platform.playerManager()
+                : Boar.getInstance().getPlayerManager();
+
+        nameToSessions.remove(event.connection().bedrockUsername());
+
+        if (playerManager == null) {
             return;
         }
 
-        if (player.future != null) {
-            player.future.cancel(false);
+        BoarPlayer player = playerManager.remove(event.connection());
+        if (player == null || player.future == null) {
+            return;
         }
 
-        nameToSessions.remove(event.connection().bedrockUsername());
+        player.future.cancel(false);
     }
 
     @Subscribe


### PR DESCRIPTION
Closes #98.

`onSessionLeave` removed the player through `Boar.getInstance().getPlayerManager()`, but that field is only set in `Boar.init`, which runs from the extension's post-initialize event. When a session disconnects before that init has completed, the field is still null and the handler throws the NPE from the report. The throw also skipped the `nameToSessions` cleanup, so the stale name stayed in that static map.

The handler now takes the manager from the extension's own platform, which holds the same object once init has run, and falls back to the static accessor when no platform exists yet. If neither is available it clears the session name and returns, so a disconnect that lands early no longer throws and no longer leaves the name behind.

```java
BoarPlayerManager<?> playerManager = this.platform != null
        ? this.platform.playerManager()
        : Boar.getInstance().getPlayerManager();
```

Testing: `./gradlew :geyser:shadowJar` on Gradle 9.4.1 with Java 21 builds clean. I could not reproduce the trigger on a local Paper and Geyser setup, because there post-initialize always runs before a session can exist. To exercise the code path instead of only the compiler, I stubbed a `GeyserConnection` with a dynamic proxy, left Boar uninitialized, and fired a `SessionDisconnectEvent`:

- old expression: `NullPointerException: Cannot invoke "ac.boar.anticheat.player.BoarPlayerManager.remove(Object)" because the return value of "ac.boar.anticheat.Boar.getPlayerManager()" is null`, the same message as the report
- patched handler: returns cleanly

I exercised the remaining branches of the handler the same way: platform absent while a manager survives, untracked session, tracked player whose ticker never started, two disconnects for one session, and a platform that carries no manager. All returned cleanly, and in the cases where a player was tracked it was removed once and its ticker cancelled once.

I have not reproduced the original environment (Velocity with Geyser, Floodgate, and a captcha plugin), so this is a defensive fix around the reported stack trace rather than a confirmed reproduction of the setup that produced it.

Not touched here, but the same hazard exists in `onGeyserShutdown`, which calls `Boar.terminate` and dereferences the manager that may not exist yet. Say the word and I will send that as a separate change.
