### PR TITLE
Fix: false flag when standing on an opening/closing shulker

### DIFF
--- a/common/src/main/java/ac/boar/anticheat/ack/BoarDefaultAcknowledgments.java
+++ b/common/src/main/java/ac/boar/anticheat/ack/BoarDefaultAcknowledgments.java
@@ -32,6 +32,7 @@ import ac.boar.anticheat.compensated.cache.container.ContainerCache;
 import ac.boar.anticheat.compensated.cache.container.impl.TradeContainerCache;
 import ac.boar.anticheat.compensated.cache.entity.EntityCache;
 import ac.boar.anticheat.data.EntityDimensions;
+import ac.boar.anticheat.data.block.BoarBlockState;
 import ac.boar.anticheat.data.inventory.ItemCache;
 import ac.boar.anticheat.data.vanilla.AttributeInstance;
 import ac.boar.anticheat.data.vanilla.StatusEffect;
@@ -41,6 +42,8 @@ import ac.boar.anticheat.prediction.engine.data.Vector;
 import ac.boar.anticheat.prediction.engine.data.VectorType;
 import ac.boar.anticheat.util.geyser.BlockEntityInfo;
 import ac.boar.anticheat.util.geyser.BoarChunk;
+import ac.boar.mappings.block.BlockMappings;
+import ac.boar.mappings.block.Properties;
 import org.cloudburstmc.math.vector.Vector3i;
 import org.cloudburstmc.protocol.bedrock.data.Ability;
 import org.cloudburstmc.protocol.bedrock.data.AbilityLayer;
@@ -118,6 +121,18 @@ public final class BoarDefaultAcknowledgments {
     }
 
     private static void handleBlockUpdate(BoarPlayer player, BlockUpdateAck ack) {
+        // Track a shulker box lid starting or stopping to move: while it animates, the bedrock
+        // player gets pushed by the lid, which the java collision view does not know about.
+        if (ack.layer() == 0) {
+            final BoarBlockState oldState = player.compensatedWorld.getBlockState(ack.position(), 0);
+            if (BlockMappings.get().getShulkerBlocks().contains(oldState.block())) {
+                final BoarBlockState newState = BoarBlockState.create(player.fromRawBlockId(ack.runtimeId()), ack.position(), 0);
+                if (BlockMappings.get().getShulkerBlocks().contains(newState.block()) && !Objects.equals(oldState.get(Properties.OPEN), newState.get(Properties.OPEN))) {
+                    player.shulkerAnimationTicks = 10;
+                }
+            }
+        }
+
         player.compensatedWorld.updateBlock(ack.position(), ack.layer(), ack.runtimeId());
     }
 

--- a/common/src/main/java/ac/boar/anticheat/packets/input/PostAuthInputPackets.java
+++ b/common/src/main/java/ac/boar/anticheat/packets/input/PostAuthInputPackets.java
@@ -43,6 +43,7 @@ public class PostAuthInputPackets implements PacketListener {
             }
 
             if (player.tickSinceBlockResync > 0) player.tickSinceBlockResync--;
+            if (player.shulkerAnimationTicks > 0) player.shulkerAnimationTicks--;
             player.getTeleportUtil().pollRewindHistory();
         }
     }

--- a/common/src/main/java/ac/boar/anticheat/player/data/PlayerData.java
+++ b/common/src/main/java/ac/boar/anticheat/player/data/PlayerData.java
@@ -159,6 +159,10 @@ public class PlayerData {
     public boolean nearBamboo;
     public boolean nearDripstone;
 
+    // The lid of a shulker box pushes the bedrock player while it animates, which java collision
+    // does not do, so the prediction needs a few ticks of lenience after an open/close update.
+    public int shulkerAnimationTicks;
+
     public boolean beingPushByLava;
 
     public final Map<Fluid, Float> fluidHeight = new HashMap<>();

--- a/common/src/main/java/ac/boar/anticheat/prediction/UncertainRunner.java
+++ b/common/src/main/java/ac/boar/anticheat/prediction/UncertainRunner.java
@@ -190,6 +190,20 @@ public class UncertainRunner {
             extra = offset;
         }
 
+        // A shulker box lid pushes the bedrock player up while it opens (and down while it closes),
+        // but the java collision boxes the prediction runs against never reproduce that push, so the
+        // player ends up higher than predicted during the animation. The lid's push tops out at half
+        // a block, so only cover offsets within that range, and keep the usual horizontal checks
+        // (no extra horizontal speed, same direction) so this cannot be abused for free movement.
+        boolean shulkerHorizontalNotExceeded = actual.horizontalLength() <= predicted.horizontalLength();
+        boolean shulkerHorizontalSaneDir = (MathUtil.sign(actual.x) == MathUtil.sign(predicted.x) || actual.x == 0)
+                && (MathUtil.sign(actual.z) == MathUtil.sign(predicted.z) || actual.z == 0);
+        if (player.shulkerAnimationTicks > 0
+                && Math.abs(player.position.y - player.unvalidatedPosition.y) <= 0.5F + player.getMaxOffset()
+                && shulkerHorizontalNotExceeded && shulkerHorizontalSaneDir) {
+            extra = offset;
+        }
+
         return extra;
     }
 }


### PR DESCRIPTION
## Problem

When a Bedrock player stands on top of a shulker box and it opens, the client gets pushed up by the animating lid, but the Java collision boxes Boar predicts against never reproduce that push. The prediction sees a position offset it cannot explain and fires a false rewind (#43). The same happens in reverse when the box closes and the lid pushes the player down.

## Fix

While a shulker lid animates, the bedrock player can be up to half a block away from the predicted position through no fault of their own. This grants up to 10 ticks of prediction lenience after the server sends an open/close update for a shulker box, under the same style of sanity checks the existing dripstone lenience uses: no extra horizontal speed, horizontal direction preserved, and vertical difference capped at 0.5 blocks plus the acceptance threshold.

Details:

- `handleBlockUpdate` detects a shulker box changing its `open` property (all 17 variants, via the existing `getShulkerBlocks()` category) and starts the countdown.
- The countdown decrements once per input packet, the same way `tickSinceBlockResync` does.
- `UncertainRunner#extraOffset` zeroes the offset for that tick when the conditions above hold.

The lenience only ever activates on a real server-side shulker update, never on anything a client can fabricate, and the gates mean it covers the lid push without allowing free vertical or horizontal movement. I chose the 10 tick window to safely cover the animation plus a tick of latency variance; it is a constant that is easy to tune.

## Testing

- `gradlew build` passes (Gradle 9.4.1, Java 21 toolchain).
- I traced the path end to end: open update at the right point in the latency-compensated timeline, countdown decrement per input tick, offset zeroing in `doPostPrediction` (which also suppresses the rewind for the affected ticks).
- I could not live-test this locally: reproducing it needs a Bedrock client standing on a shulker through Geyser. Verification so far is build plus code trace. The manual test is: stand on a shulker box, open and close it repeatedly with a second account or a redstone toggle, and confirm no `prediction-fail` rewinds appear in debug output, then sprint-jump across a row of shulker boxes to confirm normal movement still flags nothing.

## Notes

- I did not reset `shulkerAnimationTicks` on dimension switch. A leftover countdown is bounded by the gates and expires within 10 ticks, matching how other per-player uncertainty state is handled here.
- Closed-state chunks that contain an already-open shulker do not trigger the countdown, which is correct because no lid animation plays for the client in that case.

Closes #43
